### PR TITLE
remove actions from "Running Plugins" and its sub items

### DIFF
--- a/src/containers/editor/Designer/ResourceTree.tsx
+++ b/src/containers/editor/Designer/ResourceTree.tsx
@@ -38,6 +38,7 @@ export const ResourceTree = () => {
           {
             name: "running-plugins",
             title: "Running Plugins",
+            nodeType: "category",
             children: getPluginTree(
               PluginManager.getInstance().getPlugins("global")
             )

--- a/src/containers/editor/Designer/TreeBase/Title.tsx
+++ b/src/containers/editor/Designer/TreeBase/Title.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useState } from "react";
 import _ from "lodash";
 
-import { Input, Icon, Dropdown } from "antd";
+import { Input, Icon, Dropdown, message } from "antd";
 import { useDrag } from "react-dnd";
 import {
   DND_IDE_NODE_TYPE,
   resourceActions,
   loadFileStatus,
-  FileLoader
+  FileLoader,
+  checkDuplicateTreeLeaf
 } from "../../../../helpers";
 // import { SchemasContext } from "../../../Context";
 import { ActionMenu } from "./ActionMenu";
@@ -77,10 +78,15 @@ export const Title = (props: any) => {
     (e: any) => {
       const title = e.target.value;
       if (_.trim(title)) {
-        const path = resourceActions.save(dataRef, title);
-        // select on tree
-        onSelect([path]);
-        onRefresh();
+        if (!checkDuplicateTreeLeaf(dataRef, title)) {
+          const path = resourceActions.save(dataRef, title);
+          // select on treeS
+          // activeTab(path, dataRef.type)
+          onSelect([path], dataRef);
+          onRefresh();
+        } else {
+          message.error('Duplicate name');
+        }
       }
     },
     [dataRef]
@@ -109,28 +115,28 @@ export const Title = (props: any) => {
           <Icon type="close" onClick={cancelEdit} />
         </>
       ) : (
-        <a
-          className={`ant-dropdown-link node-title node-modified-${status}`}
-          href="#"
-        >
-          {newTitle}
-          {dataRef.isTemplate || dataRef.nodeType === "category" ? null : (
-            <Dropdown
-              overlay={
-                <ActionMenu
-                  onSelect={onSelect}
-                  dataRef={dataRef}
-                  onRefresh={onRefresh}
-                  {...rest}
-                  status={status}
-                />
-              }
-            >
-              <Icon type="more" />
-            </Dropdown>
-          )}
-        </a>
-      )}
+          <a
+            className={`ant-dropdown-link node-title node-modified-${status}`}
+            href="#"
+          >
+            {newTitle}
+            {dataRef.isTemplate || dataRef.nodeType === "category" ? null : (
+              <Dropdown
+                overlay={
+                  <ActionMenu
+                    onSelect={onSelect}
+                    dataRef={dataRef}
+                    onRefresh={onRefresh}
+                    {...rest}
+                    status={status}
+                  />
+                }
+              >
+                <Icon type="more" />
+              </Dropdown>
+            )}
+          </a>
+        )}
     </div>
   );
 };

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -429,14 +429,14 @@ export const getPluginTree = (plugins: any) => {
     if (_.isObject(plugin)) {
       if (plugin.type) {
         let name = _.get(plugin, "name", plugin.type);
-        result = { name: plugin.type, title: name };
+        result = { name: plugin.type, title: name, isTemplate: true };
       } else {
         let children: any = [];
         for (let k in plugin) {
           const p = plugin[k];
           children.push(getPluginSubTree(k, p));
         }
-        result = { key: _.uniqueId(key), name: key, title: key, children };
+        result = { key: _.uniqueId(key), name: key, title: key, children, isTemplate: true };
       }
     }
     if (!_.isEmpty(result)) results.push(result);
@@ -445,7 +445,7 @@ export const getPluginTree = (plugins: any) => {
 };
 
 const getPluginSubTree = (key: string, plugins: any) => {
-  const result: any = { key: _.uniqueId(key), name: key, title: key };
+  const result: any = { key: _.uniqueId(key), name: key, title: key, isTemplate: true };
   if (!plugins.type) {
     const children = getPluginTree(plugins);
     if (!_.isEmpty(children)) result.children = children;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -193,7 +193,30 @@ export function formatTitle(wording: string) {
   }
   return "";
 }
-
+export function checkDuplicate(treeNode: any, name: string) {
+  let duplicate = false;
+  if (treeNode.children && treeNode.children.length) {
+    treeNode.children.some((item: any) => {
+      duplicate = checkDuplicate(item, name)
+      if (duplicate) return true;
+    });
+  } else {
+    if (treeNode.name.split('.')[0] === name) {
+      duplicate = true;
+    }
+  }
+  return duplicate;
+}
+export function checkDuplicateTreeLeaf(treeNode: any, name: string) {
+  debugger
+  let treeRoot = getTreeRoot(treeNode);
+  let duplicate = false;
+  treeRoot.children.some((item: any) => {
+    duplicate = checkDuplicate(item, name)
+    if (duplicate) return true;
+  });
+  return duplicate;
+}
 /**
  * Format arbitary schema to stardard one
  *


### PR DESCRIPTION
fix bugs:
1. duplicate name check when add/rename treenode
2. only submit current treenode when there are more than one new treenode